### PR TITLE
Create configuration showback

### DIFF
--- a/app/models/showback_configuration.rb
+++ b/app/models/showback_configuration.rb
@@ -1,0 +1,37 @@
+class ShowbackConfiguration < ApplicationRecord
+  validates :name,        :presence   => true
+  validates :description, :presence   => true
+  validates :name,        :uniqueness => true
+  validates :types,       :presence   => true
+
+  serialize :types, Array # Implement types column as an array
+  default_value_for(:types) { [] }
+
+  VALID_MEASURE_TYPES = %w(Occurence Throughput Frequency Capacity Integer).freeze
+
+  validates :measure,
+            :inclusion => { :in => VALID_MEASURE_TYPES }
+
+  def self.seed
+    seed_data.each do |con_conf_attributtes|
+      con_conf_name = con_conf_attributtes[:name]
+      next if ShowbackConfiguration.find_by(:name => con_conf_name)
+      log_attrs = con_conf_attributtes.slice(:name, :description, :measure, :types)
+      _log.info("Creating consumption configuration with parameters #{log_attrs.inspect}")
+      _log.info("Creating #{con_conf_name} consumption configuration...")
+      con_conf = create(con_conf_attributtes)
+      con_conf.save
+      _log.info("Creating #{con_conf_name} consumption configuration... Complete")
+    end
+  end
+
+  def self.seed_file_name
+    @seed_file_name ||= Rails.root.join("db", "fixtures", "#{table_name}.yml")
+  end
+  private_class_method :seed_file_name
+
+  def self.seed_data
+    File.exist?(seed_file_name) ? YAML.load_file(seed_file_name) : []
+  end
+  private_class_method :seed_data
+end

--- a/db/fixtures/showback_configurations.yml
+++ b/db/fixtures/showback_configurations.yml
@@ -1,0 +1,17 @@
+---
+- :name: "Showback::CPU"
+  :description: "Calculate CPU Showback"
+  :measure: "Integer"
+  :types: ["cpu_usage_rate_average", "cpu_usagemhz_rate_average"]
+- :name: "Showback::MEM"
+  :description: "Calculate Memory Showback"
+  :measure: "Capacity"
+  :types: ["mem_usage_absolute_average"]
+- :name: "Showback::NET"
+  :description: "Calculate Network Showback"
+  :measure: "Throughput"
+  :types: ["net_usage_rate_average"]
+- :name: "Showback::STO"
+  :description: "Calculate Storage Showback"
+  :measure: "Capacity"
+  :types: ["disk_usage_rate_average"]

--- a/db/migrate/20170222102826_create_showback_configurations.rb
+++ b/db/migrate/20170222102826_create_showback_configurations.rb
@@ -1,0 +1,16 @@
+class CreateShowbackConfigurations < ActiveRecord::Migration[5.0]
+  def up
+    create_table :showback_configurations do |t|
+      t.string     :name
+      t.string     :description
+      t.string     :measure
+      t.text       :types
+      t.timestamp  :updated_at
+      t.timestamp  :created_at
+    end
+  end
+
+  def down
+    drop_table :showback_configurations
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -6444,6 +6444,14 @@ shares:
 - allow_tenant_inheritance
 - created_at
 - updated_at
+showback_configurations:
+- id
+- name
+- description
+- measure
+- types
+- updated_at
+- created_at
 snapshots:
 - id
 - uid

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -29,6 +29,7 @@ class EvmDatabase
     ChargeableField
     ChargebackRateDetailCurrency
     ChargebackRate
+    ShowbackConfiguration
   ).freeze
 
   RAILS_ENGINE_MODEL_CLASS_NAMES = %w(MiqAeDatastore)

--- a/spec/factories/showback_configuration.rb
+++ b/spec/factories/showback_configuration.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :showback_configuration do
+
+    sequence(:name)          { |s| "name #{s}" }
+    sequence(:description)   { |s| "Description #{s}" }
+    measure                  'Integer'
+    types                    ["cpu_usage_rate_average", "cpu_usagemhz_rate_average"]
+
+
+  end
+end

--- a/spec/models/showback_configuration_spec.rb
+++ b/spec/models/showback_configuration_spec.rb
@@ -1,0 +1,54 @@
+describe ShowbackConfiguration do
+  before do
+    @expected_showback_configuration_count = 4
+  end
+
+  context "validations" do
+    it "should ensure presence of name" do
+      expect(FactoryGirl.build(:showback_configuration, :name => nil)).not_to be_valid
+    end
+
+    it "should ensure presence of description" do
+      expect(FactoryGirl.build(:showback_configuration, :description => nil)).not_to be_valid
+    end
+
+    it "should ensure presence of measure type" do
+      expect(FactoryGirl.build(:showback_configuration, :measure => nil)).not_to be_valid
+    end
+
+    it "should invalidate incorrect measure type" do
+      expect(FactoryGirl.build(:showback_configuration, :measure => "AA")).not_to be_valid
+    end
+
+    it "should validate correct measure type" do
+      expect(FactoryGirl.build(:showback_configuration, :measure => "Integer")).to be_valid
+    end
+
+    it "should ensure presence of types" do
+      expect(FactoryGirl.build(:showback_configuration, :types => [])).not_to be_valid
+    end
+  end
+
+  context ".seed" do
+    it "empty table" do
+      ShowbackConfiguration.seed
+      expect(ShowbackConfiguration.count).to eq(@expected_showback_configuration_count)
+    end
+
+    it "run twice" do
+      ShowbackConfiguration.seed
+      ShowbackConfiguration.seed
+      expect(ShowbackConfiguration.count).to eq(@expected_showback_configuration_count)
+    end
+
+    it "with existing records" do
+      unchanged = FactoryGirl.create(:showback_configuration, :name => "xxx")
+      unchanged_orig_updated_at = unchanged.updated_at
+
+      ShowbackConfiguration.seed
+
+      expect(ShowbackConfiguration.count).to eq(@expected_showback_configuration_count + 1)
+      expect(unchanged.reload.updated_at).to be_same_time_as unchanged_orig_updated_at
+    end
+  end
+end


### PR DESCRIPTION
Showback configuration to store all types of mesures.
showbacks has one type of configuration showback.

Actually.

---
- :name: "Showback::CPU"
  :description: "Calculate CPU Showback"
  :measure: "Integer"
  :types: ["cpu_usage_rate_average", "cpu_usagemhz_rate_average"]
- :name: "Showback::MEM"
  :description: "Calculate Memory Showback"
  :measure: "Capacity"
  :types: ["mem_usage_absolute_average"]
- :name: "Showback::NET"
  :description: "Calculate Network Showback"
  :measure: "Throughput"
  :types: ["net_usage_rate_average"]
- :name: "Showback::STO"
  :description: "Calculate Storage Showback"
  :measure: "Capacity"
  :types: ["disk_usage_rate_average"]

