### PR TITLE
Create showbacks

### DIFF
--- a/app/models/showback_configuration.rb
+++ b/app/models/showback_configuration.rb
@@ -1,8 +1,5 @@
 class ShowbackConfiguration < ApplicationRecord
-  validates :name,        :presence   => true
-  validates :description, :presence   => true
-  validates :name,        :uniqueness => true
-  validates :types,       :presence   => true
+  validates :name, :description, :name, :types, :presence => true
 
   serialize :types, Array # Implement types column as an array
   default_value_for(:types) { [] }

--- a/app/models/showback_event.rb
+++ b/app/models/showback_event.rb
@@ -1,0 +1,22 @@
+class ShowbackEvent < ApplicationRecord
+  belongs_to :showback_configuration
+
+  validates :data, :start_time, :end_time, :id_obj, :type_obj, :presence => true
+  validate :start_time_before_end_time
+
+  def start_time_before_end_time
+    if start_time.to_i >= end_time.to_i
+      errors.add(:start_time, "Start time should be before end time")
+    end
+  end
+
+  serialize :data, JSON # Implement data column as a JSON
+  default_value_for(:data) { {} }
+
+  # return the parsing error message if not valid JSON; otherwise nil
+  def validate_format
+    JSON.parse(data) && nil if data.present?
+  rescue JSON::ParserError => err
+    err.message
+  end
+end

--- a/db/migrate/20170306085210_create_showback_events.rb
+++ b/db/migrate/20170306085210_create_showback_events.rb
@@ -1,0 +1,22 @@
+class CreateShowbackEvents < ActiveRecord::Migration[5.0]
+  def up
+    create_table :showback_events do |t|
+      t.json       :data
+      t.timestamp  :start_time  # when start the event
+      t.timestamp  :end_time    # when finish the event
+      t.bigint     :id_obj      # id of name model about reference the event in C&U
+      t.string     :type_obj    # name model about reference the event in C&U
+      t.bigint     :showback_configuration_id
+      t.timestamp  :updated_at
+      t.timestamp  :created_at
+    end
+    add_index  :showback_events, :id_obj
+    add_index  :showback_events, :showback_configuration_id
+  end
+
+  def down
+    remove_index  :showback_events, :id_obj
+    remove_index  :showback_events, :showback_configuration_id
+    drop_table :showback_events
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -6464,6 +6464,16 @@ showback_configurations:
 - types
 - updated_at
 - created_at
+showback_events:
+- id
+- data
+- start_time
+- end_time
+- id_obj
+- type_obj
+- showback_configuration_id
+- updated_at
+- created_at
 snapshots:
 - id
 - uid

--- a/spec/factories/showback_configuration.rb
+++ b/spec/factories/showback_configuration.rb
@@ -6,6 +6,5 @@ FactoryGirl.define do
     measure                  'Integer'
     types                    ["cpu_usage_rate_average", "cpu_usagemhz_rate_average"]
 
-
   end
 end

--- a/spec/factories/showback_event.rb
+++ b/spec/factories/showback_event.rb
@@ -1,0 +1,13 @@
+
+DATA = { 3.hours.ago => {"cpu_usage_rate_average" => 2} }.to_json
+
+FactoryGirl.define do
+  factory :showback_event do
+    data                      DATA
+    sequence(:id_obj)         { |n| 100_000 + n }
+    type_obj                  'VM'
+    start_time                4.hours.ago
+    end_time                  1.hour.ago
+    showback_configuration
+  end
+end

--- a/spec/models/showback_event_spec.rb
+++ b/spec/models/showback_event_spec.rb
@@ -1,0 +1,64 @@
+describe ShowbackEvent do
+  context "validations" do
+    let(:showback_event) { FactoryGirl.build(:showback_event) }
+
+    it "has a valid factory" do
+      expect(showback_event).to be_valid
+    end
+
+    it "should invalidate incorrect data type" do
+      showback_event.data = {}
+      showback_event.valid?
+      expect(showback_event.errors[:data]).to include "can't be blank"
+    end
+
+    it "should ensure presence of data" do
+      showback_event.data = nil
+      showback_event.valid?
+      expect(showback_event.errors[:data]).to include "can't be blank"
+    end
+
+    it "should ensure presence of start_time" do
+      showback_event.start_time = nil
+      showback_event.valid?
+      expect(showback_event.errors[:start_time]).to include "can't be blank"
+    end
+
+    it "should ensure presence of end_time" do
+      showback_event.end_time = nil
+      showback_event.valid?
+      expect(showback_event.errors[:end_time]).to include "can't be blank"
+    end
+
+    it "should fails start time is after of end time" do
+      showback_event.start_time = 1.hour.ago
+      showback_event.end_time = 4.hours.ago
+      showback_event.valid?
+      expect(showback_event.errors[:start_time]).to include "Start time should be before end time"
+    end
+
+    it "should ensure presence of id_obj" do
+      showback_event.id_obj = nil
+      showback_event.valid?
+      expect(showback_event.errors[:id_obj]).to include "can't be blank"
+    end
+
+    it "should ensure presence of type_obj" do
+      showback_event.type_obj = nil
+      showback_event.valid?
+      expect(showback_event.errors[:type_obj]).to include "can't be blank"
+    end
+  end
+
+  context '#validate_format' do
+    it 'passes validation with correct JSON data' do
+      event = FactoryGirl.create(:showback_event)
+      expect(event.validate_format).to be_nil
+    end
+
+    it 'fails validations with incorrect JSON data' do
+      event = FactoryGirl.build(:showback_event, :data => ":-Invalid:\n-JSON")
+      expect(event.validate_format).not_to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Showbacks store all events with all types of mesures with one type of configuration showback.

Showback model store the below information:
 - data: is a json
 - type_obj: name model about the event
 - id_obj: id model about the event
 - event_init: timestamp init the event
 - event_end: timestamp end the event
 - showback_configuration: associated with a showback configuration
