### PR TITLE
Monetize in showback charges

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem "inifile",                        "~>3.0",         :require => false
 gem "jbuilder",                       "~>2.5.0" # For the REST API
 gem "manageiq-api-client",            "~>0.1.0",       :require => false
 gem "mime-types",                     "~>2.6.1",       :require => "mime/types/columnar"
+gem "money-rails",                    "~>1"
 gem "more_core_extensions",           "~>3.2"
 gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)
 gem "net-ldap",                       "~>0.14.0",      :require => false

--- a/app/models/showback_charge.rb
+++ b/app/models/showback_charge.rb
@@ -3,19 +3,6 @@ class ShowbackCharge < ApplicationRecord
   belongs_to :showback_event, :inverse_of => :showback_charges
   validates :showback_bucket, :presence => true, :allow_nil => false
   validates :showback_event, :presence => true, :allow_nil => false
-  validate  :fixed_cost_big_decimal, :variable_cost_big_decimal
-
-  def fixed_cost_big_decimal
-    unless fixed_cost.nil?
-      self.fixed_cost = fixed_cost.to_d
-      errors.add(:fixed_cost, "must be of class money") unless fixed_cost.class == BigDecimal
-    end
-  end
-
-  def variable_cost_big_decimal
-    unless variable_cost.nil?
-      self.variable_cost = variable_cost.to_d
-      errors.add(:variable_cost, "must be of class money") unless variable_cost.class == BigDecimal
-    end
-  end
+  monetize :fixed_cost_cents, :with_model_currency => :fixed_cost_currency, :allow_nil => true
+  monetize :variable_cost_cents, :with_model_currency => :variable_cost_currency, :allow_nil => true
 end

--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -1,0 +1,92 @@
+# encoding : utf-8
+
+MoneyRails.configure do |config|
+
+  # To set the default currency
+  #
+  # config.default_currency = :usd
+
+  # Set default bank object
+  #
+  # Example:
+  # config.default_bank = EuCentralBank.new
+
+  # Add exchange rates to current money bank object.
+  # (The conversion rate refers to one direction only)
+  #
+  # Example:
+  # config.add_rate "USD", "CAD", 1.24515
+  # config.add_rate "CAD", "USD", 0.803115
+
+  # To handle the inclusion of validations for monetized fields
+  # The default value is true
+  #
+  # config.include_validations = true
+
+  # Default ActiveRecord migration configuration values for columns:
+  #
+  # config.amount_column = { prefix: '',           # column name prefix
+  #                          postfix: '_cents',    # column name  postfix
+  #                          column_name: nil,     # full column name (overrides prefix, postfix and accessor name)
+  #                          type: :integer,       # column type
+  #                          present: true,        # column will be created
+  #                          null: false,          # other options will be treated as column options
+  #                          default: 0
+  #                        }
+  #
+  # config.currency_column = { prefix: '',
+  #                            postfix: '_currency',
+  #                            column_name: nil,
+  #                            type: :string,
+  #                            present: true,
+  #                            null: false,
+  #                            default: 'USD'
+  #                          }
+
+  # Register a custom currency
+  #
+  # Example:
+  # config.register_currency = {
+  #   :priority            => 1,
+  #   :iso_code            => "EU4",
+  #   :name                => "Euro with subunit of 4 digits",
+  #   :symbol              => "€",
+  #   :symbol_first        => true,
+  #   :subunit             => "Subcent",
+  #   :subunit_to_unit     => 10000,
+  #   :thousands_separator => ".",
+  #   :decimal_mark        => ","
+  # }
+
+  # Specify a rounding mode
+  # Any one of:
+  #
+  # BigDecimal::ROUND_UP,
+  # BigDecimal::ROUND_DOWN,
+  # BigDecimal::ROUND_HALF_UP,
+  # BigDecimal::ROUND_HALF_DOWN,
+  # BigDecimal::ROUND_HALF_EVEN,
+  # BigDecimal::ROUND_CEILING,
+  # BigDecimal::ROUND_FLOOR
+  #
+  # set to BigDecimal::ROUND_HALF_EVEN by default
+  #
+  # config.rounding_mode = BigDecimal::ROUND_HALF_UP
+
+  # Set default money format globally.
+  # Default value is nil meaning "ignore this option".
+  # Example:
+  #
+  # config.default_format = {
+  #   :no_cents_if_whole => nil,
+  #   :symbol => nil,
+  #   :sign_before_symbol => nil
+  # }
+
+  # Set default raise_error_on_money_parsing option
+  # It will be raise error if assigned different currency
+  # The default value is false
+  #
+  # Example:
+  # config.raise_error_on_money_parsing = false
+end

--- a/db/migrate/20170411212254_change_costs_as_monetize_in_showback_charges.rb
+++ b/db/migrate/20170411212254_change_costs_as_monetize_in_showback_charges.rb
@@ -1,0 +1,15 @@
+class ChangeCostsAsMonetizeInShowbackCharges < ActiveRecord::Migration[5.0]
+  def up
+    remove_column :showback_charges, :fixed_cost, :decimal
+    remove_column :showback_charges, :variable_cost, :decimal
+    add_monetize :showback_charges, :fixed_cost, :amount => { :null => true, :default => nil }
+    add_monetize :showback_charges, :variable_cost, :amount => { :null => true, :default => nil }
+  end
+
+  def down
+    remove_monetize :showback_charges, :variable_cost
+    remove_monetize :showback_charges, :fixed_cost
+    add_column :showback_charges, :variable_cost, :decimal
+    add_column :showback_charges, :fixed_cost, :decimal
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -6490,12 +6490,14 @@ showback_buckets:
 - updated_at
 showback_charges:
 - id
-- fixed_cost
-- variable_cost
 - showback_bucket_id
 - showback_event_id
 - created_at
 - updated_at
+- fixed_cost_cents
+- fixed_cost_currency
+- variable_cost_cents
+- variable_cost_currency
 showback_events:
 - id
 - data

--- a/spec/factories/showback_charge.rb
+++ b/spec/factories/showback_charge.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :showback_charge do
     showback_bucket
     showback_event
-    fixed_cost nil
-    variable_cost nil
+    fixed_cost 0
+    variable_cost 0
   end
 end

--- a/spec/models/showback_bucket_spec.rb
+++ b/spec/models/showback_bucket_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe ShowbackBucket, :type => :model do
       expect { bucket.showback_events << event }.to change(bucket.showback_charges, :count).by(1)
       charge = bucket.showback_charges.last
       expect(charge.showback_event).to eq(event)
-      expect { charge.fixed_cost = 3 }.to change(charge, :fixed_cost).from(nil).to(3)
+      expect { charge.fixed_cost = Money.new(3) }.to change(charge, :fixed_cost).from(nil).to(Money.new(3))
     end
 
     it 'events can be associated to variable costs' do
@@ -76,7 +76,7 @@ RSpec.describe ShowbackBucket, :type => :model do
       expect { bucket.showback_events << event }.to change(bucket.showback_charges, :count).by(1)
       charge = bucket.showback_charges.last
       expect(charge.showback_event).to eq(event)
-      expect { charge.variable_cost = 3 }.to change(charge, :variable_cost).from(nil).to(3)
+      expect { charge.variable_cost = Money.new(3) }.to change(charge, :variable_cost).from(nil).to(Money.new(3))
     end
 
     pending 'charges can be updated for an event'

--- a/spec/models/showback_charge_spec.rb
+++ b/spec/models/showback_charge_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ShowbackCharge, :type => :model do
     expect(charge).to be_valid
   end
 
-  it 'is valid when assigning fixed_costs' do
+  it 'is valid when assigning fixed_cost' do
     charge.fixed_cost = 15
     charge.valid?
     expect(charge).to be_valid


### PR DESCRIPTION
Monetize the attributes fixed_cost and variable_cost in showback charges using Money.

Taks:
- Add migration file to monetize the attributes fixed_cost and variable_cost.
- Update rspecs to use Money.
- Cleanup the validations for attributes fixed_cost and variable_cost.

Address #33 

