### PR TITLE
Improve Specs for models ShowbackCharge and ShowbackRate

### DIFF
--- a/spec/models/showback_charge_spec.rb
+++ b/spec/models/showback_charge_spec.rb
@@ -37,6 +37,71 @@ RSpec.describe ShowbackCharge, :type => :model do
     expect(charge).to be_valid
   end
 
-  pending 'is not valid if fixed cost is not money'
-  pending 'is not valid if variable cost is not money'
+  it 'is valid when assigning variable_cost' do
+    charge.variable_cost = 30
+    charge.valid?
+    expect(charge).to be_valid
+  end
+
+  it 'is not valid if fixed cost is not money' do
+    charge.fixed_cost = 'cost'
+    charge.valid?
+    expect(charge.errors.details[:fixed_cost]).to include(:error => :not_a_number, :value => "cost")
+  end
+
+  it 'is not valid if variable cost is not money' do
+    charge.variable_cost = 'cost'
+    charge.valid?
+    expect(charge.errors.details[:variable_cost]).to include(:error => :not_a_number, :value => "cost")
+  end
+
+  it "fixed_cost expected to be Money" do
+    expect(FactoryGirl.create(:showback_charge, :fixed_cost => Money.new("5.9234892348923"))).to be_valid
+    expect(ShowbackCharge).to monetize(:fixed_cost)
+  end
+
+  it "variable_cost expected to be Money" do
+    expect(FactoryGirl.create(:showback_charge, :variable_cost => Money.new("71.2348723487"))).to be_valid
+    expect(ShowbackCharge).to monetize(:variable_cost)
+  end
+
+  it 'correctly assigns Integer objects to the fixed_costs' do
+    charge.fixed_cost = 33
+    expect(charge.fixed_cost).to eq Money.new(3300, 'USD')
+  end
+
+  it 'correctly assigns String objects to the fixed_costs' do
+    charge.fixed_cost = "12"
+    expect(charge.fixed_cost).to eq Money.new(1200, 'USD')
+  end
+
+  it 'correctly assigns Integer objects to the fixed_cost_cents' do
+    charge.fixed_cost_cents = 69
+    expect(charge.fixed_cost).to eq Money.new(69, 'USD')
+  end
+
+  it 'correctly assigns Money objects to the fixed_costs' do
+    charge.fixed_cost = Money.new(81, 'USD')
+    expect(charge.fixed_cost).to eq Money.new(81, 'USD')
+  end
+
+  it 'correctly assigns Integer objects to the variable_cost' do
+    charge.variable_cost = 33
+    expect(charge.variable_cost).to eq Money.new(3300, 'USD')
+  end
+
+  it 'correctly assigns String objects to the variable_cost' do
+    charge.variable_cost = "12"
+    expect(charge.variable_cost).to eq Money.new(1200, 'USD')
+  end
+
+  it 'correctly assigns Integer objects to the variable_cost_cents' do
+    charge.variable_cost_cents = 69
+    expect(charge.variable_cost).to eq Money.new(69, 'USD')
+  end
+
+  it 'correctly assigns Money objects to the variable_cost' do
+    charge.variable_cost = Money.new(81, 'USD')
+    expect(charge.variable_cost).to eq Money.new(81, 'USD')
+  end
 end

--- a/spec/models/showback_rate_spec.rb
+++ b/spec/models/showback_rate_spec.rb
@@ -42,14 +42,78 @@ describe ShowbackRate do
       expect(showback_rate.errors.details[:dimension]).to include(:error=>:blank)
     end
 
+    it 'is valid when assigning fixed_rate' do
+      showback_rate.fixed_rate = 15
+      showback_rate.valid?
+      expect(showback_rate).to be_valid
+    end
+
+    it 'is valid when assigning variable_rate' do
+      showback_rate.variable_rate = 30
+      showback_rate.valid?
+      expect(showback_rate).to be_valid
+    end
+
+    it 'is not valid if fixed rate is not money' do
+      showback_rate.fixed_rate = 'cost'
+      showback_rate.valid?
+      expect(showback_rate.errors.details[:fixed_rate]).to include(:error => :not_a_number, :value => "cost")
+    end
+
+    it 'is not valid if variable rate is not money' do
+      showback_rate.variable_rate = 'cost'
+      showback_rate.valid?
+      expect(showback_rate.errors.details[:variable_rate]).to include(:error => :not_a_number, :value => "cost")
+    end
+
     it "fixed_rate expected to be Money" do
       expect(FactoryGirl.create(:showback_rate, :fixed_rate => Money.new("2.5634525342534"))).to be_valid
       expect(ShowbackRate).to monetize(:fixed_rate)
     end
 
-    it "variable_rate expected to be BigDeciaml" do
+    it "variable_rate expected to be Money" do
       expect(FactoryGirl.create(:showback_rate, :variable_rate => Money.new("67.4525342534"))).to be_valid
       expect(ShowbackRate).to monetize(:variable_rate)
+    end
+
+    it 'correctly assigns Integer objects to the fixed_rate' do
+      showback_rate.fixed_rate = 15
+      expect(showback_rate.fixed_rate).to eq Money.new(1500, 'USD')
+    end
+
+    it 'correctly assigns String objects to the fixed_rate' do
+      showback_rate.fixed_rate = "23"
+      expect(showback_rate.fixed_rate).to eq Money.new(2300, 'USD')
+    end
+
+    it 'correctly assigns Integer objects to the fixed_rate_cents' do
+      showback_rate.fixed_rate_cents = 66
+      expect(showback_rate.fixed_rate).to eq Money.new(66, 'USD')
+    end
+
+    it 'correctly assigns Money objects to the fixed_rate' do
+      showback_rate.fixed_rate = Money.new(82, 'USD')
+      expect(showback_rate.fixed_rate).to eq Money.new(82, 'USD')
+    end
+
+    it 'correctly assigns Integer objects to the variable_rate' do
+      showback_rate.variable_rate = 15
+      expect(showback_rate.variable_rate).to eq Money.new(1500, 'USD')
+    end
+
+    it 'correctly assigns String objects to the variable_rate' do
+      showback_rate.variable_rate = "23"
+      expect(showback_rate.variable_rate).to eq Money.new(2300, 'USD')
+    end
+
+    it 'correctly assigns Integer objects to the variable_rate_cents' do
+      showback_rate.variable_rate_cents = 66
+      expect(showback_rate.variable_rate).to eq Money.new(66, 'USD')
+    end
+
+    it 'correctly assigns Money objects to the variable_rate' do
+      showback_rate.variable_rate = Money.new(82, 'USD')
+      expect(showback_rate.variable_rate).to eq Money.new(82, 'USD')
     end
   end
 end


### PR DESCRIPTION
This PR contains new specs for model showback_charge and showback_rate. I had completed 2 pending specs for model showback_charge. In addition, I added specs to check correctly assigns Integer, Strings and Money objects to monetize attributes.
